### PR TITLE
Compatibility version for version 2 and 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,9 +32,3 @@ This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypack
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
-
-Fork notes
----------
-
-Compatibility version for Python 3 and 2
-Please don't run setup.py yet. Haven't updated it yet. If you want, you may fork from here or from the main-branch

--- a/README.rst
+++ b/README.rst
@@ -2,22 +2,6 @@
 google-search
 =============
 
-
-.. image:: https://img.shields.io/pypi/v/google-search.svg
-        :target: https://pypi.python.org/pypi/google-search
-
-.. image:: https://img.shields.io/travis/anthonyhseb/googlesearch.svg
-        :target: https://travis-ci.org/anthonyhseb/googlesearch
-
-.. image:: https://readthedocs.org/projects/googlesearch/badge/?version=latest
-        :target: https://googlesearch.readthedocs.io/en/latest/?badge=latest
-        :alt: Documentation Status
-
-.. image:: https://pyup.io/repos/github/anthonyhseb/googlesearch/shield.svg
-     :target: https://pyup.io/repos/github/anthonyhseb/googlesearch/
-     :alt: Updates
-
-
 Library for scraping google search results.
 
 * Usage::
@@ -49,3 +33,7 @@ This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypack
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
 
+Fork notes
+---------
+
+Compatibility version for Python 3 and 2

--- a/README.rst
+++ b/README.rst
@@ -37,3 +37,4 @@ Fork notes
 ---------
 
 Compatibility version for Python 3 and 2
+Please don't run setup.py yet. Haven't updated it yet. If you want, you may fork from here or from the main-branch

--- a/googlesearch/googlesearch.py
+++ b/googlesearch/googlesearch.py
@@ -3,14 +3,24 @@ Created on May 5, 2017
 
 @author: anthony
 '''
-import urllib2
+##compact
+
+import sys
+if sys.version_info < (3,):
+    import urllib2
+else:
+    import urllib
+    import urllib.request
+    import urllib.parse
 import math
 import re
 from bs4 import BeautifulSoup
-from pprint import pprint
 from threading import Thread
 from collections import deque
 from time import sleep
+from unidecode import unidecode
+
+
         
 class GoogleSearch:
     USER_AGENT = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/ 58.0.3029.81 Safari/537.36"
@@ -23,21 +33,81 @@ class GoogleSearch:
             ("Accept-Language", "en-US,en;q=0.5"),
         ]
     
-    def search(self, query, num_results = 10, prefetch_pages = True, prefetch_threads = 10):
+    def search(self, query, as_epq = None, as_oq= None, as_eq = None, filetype = None, site = None, as_qdr = None, intitle = None, inurl = None,
+        as_rq = None, as_lq = None, lr = None, cr = 0, hl = None, num_results = 10, prefetch_pages = True, prefetch_threads = 1):
+        '''
+        Query Google returning a SearchResult object.
+
+        Keyword arguments:
+        query: The search query (required)
+        as_epq: Force the search to include the text. Useful for search filters to include the given text. Uses AND filter.
+        as_oq:  Force the search to include the text. More advanced version of the one above but using the OR filter.
+        as_eq: Force the search to exclude the text. Results must NOT include any words in this string.
+        filetype: Only returns results that end in .text. Eg to get pdf files simply put filetype= pdf
+        site: Force the search to include results from a given site. ie Limits results to just the site you choose.
+        as_qdr: Limit the search results to include theresult included from the given time.
+        intitle: Force the seach to include the text in the title.
+        inurl: Force the seach to include the text in the url.
+        as_rq: Finds sites Google thinks are related to the URL you put in.
+        as_lq: Finds sites that link to the URL you put in.
+        lr: Limits the languages used to return results. Not hugely effective.
+        cr: Limits the search results to pages/sites from certain locations. Default 0 for your home country.
+            Change it to include results from another country
+        hl: Interface language.
+        num_results: Maxximum numer of results to be searched. Use lower number to get faster results. (Default value= 10)
+        prefetch_pages: By default the result URLs are fetched eagerly when the search request is made. (Default value= True)
+                        Fetching can be deferred until searchResult.getText() or getMarkup() are called by passing prefetch_results = False
+        prefetch_threads: Only works when prefetch_results= True. (Default value= 1)
+                         Searches the queries in seperate threads. For best results set to the maximum number your processor supports.
+                         For optimum reasons it will reset it to the number of processor cores if it is 1.
+
+        Returns:
+        A SearchResult object
+        '''
         searchResults = []
-        pages = int(math.ceil(num_results / float(GoogleSearch.RESULTS_PER_PAGE)));
+        if prefetch_threads==1:
+            import psutil
+            prefetch_threads = psutil.cpu_count()
+        if sys.version_info < (3,):
+            squery = urllib2.quote(query) + ("" if intitle==None else ("+&intitle%3A\"" + urllib2.quote(intitle) + "\"")) + \
+                ("" if intitle==None else ("+&inurl%3A\"" + urllib2.quote(inurl) + "\""))  + ("" if site==None else ("&+site%3A\"" + urllib2.quote(site) + "\""))
+        else:
+            squery = urllib.parse.quote(query) + ("" if intitle==None else ("+&intitle%3A\"" + urllib.parse.quote(intitle) + "\"")) + \
+                ("" if inurl==None else ("+&inurl%3A\"" + urllib.parse.quote(inurl) + "\"")) + ("" if site==None else ("&+site%3A\"" + urllib.parse.quote(site) + "\""))
+        pages = int(math.ceil(num_results / float(GoogleSearch.RESULTS_PER_PAGE)))
         fetcher_threads = deque([])
         total = None;
         for i in range(pages) :
-            start = i * GoogleSearch.RESULTS_PER_PAGE
-            opener = urllib2.build_opener()
-            opener.addheaders = GoogleSearch.DEFAULT_HEADERS
-            response = opener.open(GoogleSearch.SEARCH_URL + "?q="+ urllib2.quote(query) + ("" if start == 0 else ("&start=" + str(start))))
+            startp = i * GoogleSearch.RESULTS_PER_PAGE
+            if sys.version_info < (3,):
+                opener = urllib2.build_opener()
+                opener.addheaders = GoogleSearch.DEFAULT_HEADERS
+                response = opener.open(GoogleSearch.SEARCH_URL + "?q="+ squery + ("" if as_epq==None else ("&as_epq=" + urllib2.quote(as_epq))) + \
+                    ("" if as_oq==None else ("&as_oq=" + urllib2.quote(as_oq))) + ("" if as_eq==None else ("&as_eq=" + urllib2.quote(as_eq))) + \
+                    ("" if filetype==None else ("&as_filetype=" + urllib2.quote(filetype))) + ("" if startp == 0 else ("&start=" + str(startp))) + \
+                    ("" if as_qdr==None else ("&as_qdr=" + urllib2.quote(as_qdr))) + ("" if as_rq==None else ("&as_rq=" + urllib2.quote(as_rq))) + \
+                    ("" if as_lq==None else ("&as_lq=" + urllib2.quote(as_lq))) + ("" if hl==None else ("&hl=" + urllib2.quote(hl))) + "&cr=" + str(cr))
+            else:
+                opener = urllib.request.build_opener()
+                opener.addheaders = GoogleSearch.DEFAULT_HEADERS
+                response = opener.open(GoogleSearch.SEARCH_URL + "?q="+ squery + ("" if as_epq==None else ("&as_epq=" + urllib.parse.quote(as_epq))) + \
+                    ("" if as_oq==None else ("&as_oq=" + urllib.parse.quote(as_oq))) + ("" if as_eq==None else ("&as_eq=" + urllib.parse.quote(as_eq))) + \
+                    ("" if filetype==None else ("&as_filetype=" + urllib.parse.quote(filetype))) + ("" if startp == 0 else ("&start=" + str(startp))) + \
+                    ("" if as_qdr==None else ("&as_qdr=" + urllib.parse.quote(as_qdr))) + ("" if as_rq==None else ("&as_rq=" + urllib.parse.quote(as_rq))) + \
+                    ("" if as_lq==None else ("&as_lq=" + urllib.parse.quote(as_lq))) + ("" if hl==None else ("&hl=" + urllib.parse.quote(hl))) + "&cr=" + str(cr))
+                #response = opener.open(surl)
             soup = BeautifulSoup(response.read(), "lxml")
             response.close()
             if total is None:
-                totalText = soup.select(GoogleSearch.TOTAL_SELECTOR)[0].children.next().encode('utf-8')
-                total = long(re.sub("[', ]", "", re.search("(([0-9]+[', ])*[0-9]+)", totalText).group(1)))
+                if sys.version_info < (3,):
+                    totalText = soup.select(GoogleSearch.TOTAL_SELECTOR)[0].children.next().encode('utf-8')
+                    total = int(re.sub("[', ]", "", re.search("(([0-9]+[', ])*[0-9]+)", totalText).group(1)))
+                else:
+                    totalText = soup.select(GoogleSearch.TOTAL_SELECTOR)[0].children.__next__().encode('utf-8')
+                    ch1 = soup.select(GoogleSearch.TOTAL_SELECTOR)[0].children
+                    totalText = soup.select(GoogleSearch.TOTAL_SELECTOR)[0].children.__next__().encode('utf-8')
+                    r1 = re.search(b"(([0-9]+[',\. ])*[0-9]+)", totalText)
+                    total = int(re.sub(b"[',\. ]", b"", r1.group(1)))
             results = self.parseResults(soup.select(GoogleSearch.RESULT_SELECTOR))
             if len(searchResults) + len(results) > num_results:
                 del results[num_results - len(searchResults):]
@@ -84,12 +154,15 @@ class SearchResult:
             soup = BeautifulSoup(self.getMarkup(), "lxml")
             for junk in soup(["script", "style"]):
                 junk.extract()
-                self.__text = soup.get_text()
+                self.__text = unidecode(soup.get_text())
         return self.__text
     
     def getMarkup(self):
         if self.__markup is None:
-            opener = urllib2.build_opener()
+            if sys.version_info < (3,):
+                opener = urllib2.build_opener()
+            else:
+                opener = urllib.request.build_opener()
             opener.addheaders = GoogleSearch.DEFAULT_HEADERS
             response = opener.open(self.url);
             self.__markup = response.read()
@@ -103,7 +176,6 @@ class SearchResult:
         return self.__str__()
 
 if __name__ == "__main__":
-    import sys
     search = GoogleSearch()
     i=1
     query = " ".join(sys.argv[1:])

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,3 +7,4 @@ coverage==4.1
 Sphinx==1.4.8
 cryptography==1.7
 PyYAML==3.11
+unidecode>=1.0.22

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-	'beautifulsoup4',
+    'beautifulsoup4',
 	'lxml',
     'unidecode',
 ]
@@ -23,9 +23,10 @@ setup(
     version='1.0.0.1',
     description="Library for scraping google search results",
     long_description=readme + '\n\n' + history,
-    author="Souyama",
-    author_email='souyamadebnath@gmail.com',
-    url='https://github.com/Souyama/googlesearch',
+    author="Anthony Hseb",
+    author_email='anthony.hseb@hotmail.com',
+    url='https://github.com/anthonyhseb/googlesearch',
+    
     packages=[
         'googlesearch',
     ],

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ with open('HISTORY.rst') as history_file:
 requirements = [
 	'beautifulsoup4',
 	'lxml',
+    'unidecode',
 ]
 
 test_requirements = [
@@ -19,12 +20,12 @@ test_requirements = [
 
 setup(
     name='google-search',
-    version='1.0.0',
+    version='1.0.0.1',
     description="Library for scraping google search results",
     long_description=readme + '\n\n' + history,
-    author="Anthony Hseb",
-    author_email='anthony.hseb@hotmail.com',
-    url='https://github.com/anthonyhseb/googlesearch',
+    author="Souyama",
+    author_email='souyamadebnath@gmail.com',
+    url='https://github.com/Souyama/googlesearch',
     packages=[
         'googlesearch',
     ],
@@ -42,6 +43,8 @@ setup(
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
     ],
     test_suite='tests',
     tests_require=test_requirements


### PR DESCRIPTION
Finally! The pull request. Tested on Python 2.7 and Python 3.6. Should theoretically work on any version greater than version 2.5.

**Fixed/ Added:**
- support for both Python 3.x,
- Added docstring to the search function
- Unidecode library for improved parsing
- Better thread control

**Issues needed to address/ not fixed**

- Support for non-latin character.
- Better doccumentation or at least upgrade the readme file.
- Handle unicode errors. For a while I thought the problem was related to Python 3 but the problem remains much bigger for Python 2. Here's a sample error thrown in Python 2:
```
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "C:\Python27\lib\encodings\cp437.py", line 12, in encode
    return codecs.charmap_encode(input,errors,encoding_map)
UnicodeEncodeError: 'charmap' codec can't encode character u'\u2013' in position 19: character maps to <undefined>
```

As for the Tox tests, unless you have some explicit filters this pull request should work. The setup file runs properly even for fresh installations. And the install library don't throw any error (well it shouldn't as much as I have seen, except for the ones above).

Well kudos, that's all I gotta say.